### PR TITLE
Add the vue-autonumeric component

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -17,6 +17,7 @@
 - [vue-mugen-scroll](https://github.com/egoist/vue-mugen-scroll), vue:2.0, links:[doc](https://github.com/egoist/vue-mugen-scroll)|[demo](https://egoist.moe/vue-mugen-scroll/), status:stable
 - [vue-timeago](https://github.com/egoist/vue-timeago), vue:2.0, links:[doc](https://github.com/egoist/vue-timeago)|[demo](https://egoist.moe/vue-timeago/), status:stable
 - [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller), vue:2.0, links:[demo](https://akryum.github.io/vue-virtual-scroller/), status:stable
+- [vue-autonumeric](https://github.com/autoNumeric/vue-autoNumeric), vue:2.0, links:[doc](https://github.com/autoNumeric/vue-autoNumeric/blob/master/README.md)|[demo](https://codepen.io/AnotherLinuxUser/pen/pWgOrZ?editors=1010)|[website](http://autonumeric.org)|[examples](http://autonumeric.org/#/guide), badge:official, status:stable
 
 # Data
 


### PR DESCRIPTION
### Find and explain a common use case
The use case is allowing any user to easily add a input managed by the AutoNumeric library, while being sure both Vue and AutoNumeric interacts correctly with each other.
Entering numbers and currencies in a website is a pretty usual use case! You'd better do it with the best mask library around :)

### Provide a Demo
You can see the `vue-autonumeric` component in action on the [official documentation](http://autonumeric.org/#/guide), and a live editable demo is available [here](https://codepen.io/AnotherLinuxUser/pen/pWgOrZ?editors=1010).

### Document the package
The component [documentation](https://github.com/autoNumeric/vue-autoNumeric/blob/master/README.md) is complete and maintained.

### Distribution
As described in the [doc](https://github.com/autoNumeric/vue-autoNumeric#installation), you can either use a CDN like `<script src="//unpkg.com/autonumeric"></script>`, or directly import the `VueAutonumeric` component (`import VueAutonumeric from 'vue-autonumeric';`) after having it installed with `npm install vue-autonumeric --save`.

### Tests
This is the only thing missing from now, but since I am dogfooding my own library (AutoNumeric and vue-autonumeric), it should be bug-free :)

### Visual Quality
This point is moot since the component manages how the `<input>` element reacts to the user input and key strokes, but does not include any CSS nor modify the element appearance.

### Activity
The component is actively maintained (the same way the AutoNumeric library is) and any issue is and will be dealt with as quickly as possible.