### PR TITLE
Add Vue-APlayer

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -17,6 +17,7 @@
 - [vue-mugen-scroll](https://github.com/egoist/vue-mugen-scroll), vue:2.0, links:[doc](https://github.com/egoist/vue-mugen-scroll)|[demo](https://egoist.moe/vue-mugen-scroll/), status:stable
 - [vue-timeago](https://github.com/egoist/vue-timeago), vue:2.0, links:[doc](https://github.com/egoist/vue-timeago)|[demo](https://egoist.moe/vue-timeago/), status:stable
 - [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller), vue:2.0, links:[demo](https://akryum.github.io/vue-virtual-scroller/), status:stable
+- [Vue-APlayer](https://github.com/SevenOutman/vue-aplayer), vue:2.0, links:[demo](https://vue-aplayer.js.org), status:stable
 
 # Data
 


### PR DESCRIPTION
### Category: UI Components
[Vue-APlayer](https://github.com/SevenOutman/vue-aplayer) is a nice and simple music player component for Vue 2.x. It's super easy to use that you can instantly have a beautiful music player with nearly zero config. And you have access to all the features it has via easy props and apis.

#### Common Use Case
Anyone who wants a music player on his page.

#### Demo and Docs
Live demo here https://vue-aplayer.js.org
Also got a screenshot here
![Screenshot](https://camo.githubusercontent.com/0c2fcfe67010076f4b3db4b3a012ed765d86d6e8/68747470733a2f2f692e6c6f6c692e6e65742f323031382f30352f32362f356230393132636532653235302e706e67)
And [documentation here](https://github.com/SevenOutman/vue-aplayer/blob/develop/docs/README.md)

#### Distribution
Vue-APlayer is packed up by webpack in `umd` format. Its stable releases are available via npm and CDN.

#### Activity
Vue-APlayer is under active maintenance and development.