### PR TITLE
Add Vue2-leaflet as UI components

### DIFF
--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -17,6 +17,7 @@
 - [vue-mugen-scroll](https://github.com/egoist/vue-mugen-scroll), vue:2.0, links:[doc](https://github.com/egoist/vue-mugen-scroll)|[demo](https://egoist.moe/vue-mugen-scroll/), status:stable
 - [vue-timeago](https://github.com/egoist/vue-timeago), vue:2.0, links:[doc](https://github.com/egoist/vue-timeago)|[demo](https://egoist.moe/vue-timeago/), status:stable
 - [vue-virtual-scroller](https://github.com/Akryum/vue-virtual-scroller), vue:2.0, links:[demo](https://akryum.github.io/vue-virtual-scroller/), status:stable
+- [vue2-leaflet](https://github.com/KoRiGaN/Vue2Leaflet), vue:2.0, links:[doc](https://korigan.github.io/Vue2Leaflet/#/)|[demo](https://korigan.github.io/Vue2Leaflet/examples/), status:stable
 
 # Data
 


### PR DESCRIPTION
Leaflet is a popular mapping (and not only) library, vue2-leaflet aims to allow the user to reason and configure leaflet trough the uses of components. As of version 2.x the library support tree-shaking to avoid to add unnecessary weight to the bundle.

vue2-leaflet has the full api documented, all of the component come with an example and a playground, dedicated documentation for nuxt and a FAQ section. a lot of examples are added with source code reachable in Git. Unit test are growing with dedicated contributors, issues are answered reasonably fast.

There is a good number of additional plugin for vue2-leaflet and are listed in our docs.

Note: I am not the author but I am the current maintainer, since the original author is MIA since almost one year.